### PR TITLE
Update tasks to use region variable

### DIFF
--- a/modules/ecs/tasks/db_migrate_task_definition.json
+++ b/modules/ecs/tasks/db_migrate_task_definition.json
@@ -8,7 +8,7 @@
       "logDriver": "awslogs",
       "options": {
         "awslogs-group": "${log_group}",
-        "awslogs-region": "us-east-1",
+        "awslogs-region": "${region}",
         "awslogs-stream-prefix": "db_migrate"
       }
     },

--- a/modules/ecs/tasks/web_task_definition.json
+++ b/modules/ecs/tasks/web_task_definition.json
@@ -14,7 +14,7 @@
       "logDriver": "awslogs",
       "options": {
         "awslogs-group": "${log_group}",
-        "awslogs-region": "us-east-1",
+        "awslogs-region": "${region}",
         "awslogs-stream-prefix": "web"
       }
     },


### PR DESCRIPTION
My talks were failing to start due to there being an inconsistent use of `region`. This change changes the hard coded `us-east-1` values to use the region variable.